### PR TITLE
Fix bug related to backups temporal directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 backups_role_restic_version: '0.9.3'
 backups_role_script_path: '/opt/backup'
-backups_role_tmp_path: '/tmp/backups'
+backups_role_tmp_path: "{{ backups_role_script_path }}/.tmp"
 backups_role_config_paths:
     - '/etc'
     - '/root'

--- a/templates/cron-main.sh.j2
+++ b/templates/cron-main.sh.j2
@@ -3,5 +3,11 @@
 # Exit with error code 1 if any command fails
 set -e
 
+# Create temporal directory
+mkdir -p "{{ backups_role_tmp_path }}"
+
 # Execute scripts in chain if error code is ok
 {{ backups_role_script_prepare }} && {{ backups_role_script_upload }}
+
+# Remove temporal directory
+rm -rf "{{ backups_role_tmp_path }}"

--- a/templates/cron-main.sh.j2
+++ b/templates/cron-main.sh.j2
@@ -3,11 +3,17 @@
 # Exit with error code 1 if any command fails
 set -e
 
+# Remove temporal directory
+function clean {
+  rm -rf "{{ backups_role_tmp_path }}"
+}
+
+# Set up an exit trap to delete temporal directory
+#+ even if there are errors before exiting.
+trap clean EXIT
+
 # Create temporal directory
 mkdir -p "{{ backups_role_tmp_path }}"
 
 # Execute scripts in chain if error code is ok
 {{ backups_role_script_prepare }} && {{ backups_role_script_upload }}
-
-# Remove temporal directory
-rm -rf "{{ backups_role_tmp_path }}"

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -26,14 +26,3 @@ echo "
 "
 restic check
 echo "...done"
-
-echo "
-## Remove temporal files ##
-"
-rm -f \
-  {% if backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
-	{{ backups_role_tmp_path }}/pg_dump \
-	{{ backups_role_tmp_path }}/config.tar.gz \
-  {% endif %}
-  {{ backups_role_assets_paths | join(' ') }}
-echo "...done"

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -3,12 +3,9 @@
 # Exit with error code 1 if any command fails
 set -e
 
-function title {
-  echo -e "\n## $1 ##" | tee -a /dev/fd/2;
-  date | tee -a /dev/fd/2;
-}
-
-title "Restic backup"
+echo "
+## Restic backup ##
+"
 restic backup \
   {% if backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
 	{{ backups_role_tmp_path }}/pg_dump \
@@ -18,10 +15,14 @@ restic backup \
 
 echo "...done"
 
-title "Restic forget"
+echo "
+## Restic forget ##
+"
 restic forget --keep-last 5 --prune
 echo "...done"
 
-title "Restic check"
+echo "
+## Restic check ##
+"
 restic check
 echo "...done"

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -30,5 +30,10 @@ echo "...done"
 echo "
 ## Remove temporal files ##
 "
-rm -rf "{{ backups_role_tmp_path  }}"
+rm -f \
+  {% if backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
+	{{ backups_role_tmp_path }}/pg_dump \
+	{{ backups_role_tmp_path }}/config.tar.gz \
+  {% endif %}
+  {{ backups_role_assets_paths | join(' ') }}
 echo "...done"

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -3,9 +3,12 @@
 # Exit with error code 1 if any command fails
 set -e
 
-echo "
-## Restic backup ##
-"
+function title {
+  echo -e "\n## $1 ##" | tee -a /dev/fd/2;
+  date | tee -a /dev/fd/2;
+}
+
+title "Restic backup"
 restic backup \
   {% if backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
 	{{ backups_role_tmp_path }}/pg_dump \
@@ -15,14 +18,10 @@ restic backup \
 
 echo "...done"
 
-echo "
-## Restic forget ##
-"
+title "Restic forget"
 restic forget --keep-last 5 --prune
 echo "...done"
 
-echo "
-## Restic check ##
-"
+title "Restic check"
 restic check
 echo "...done"


### PR DESCRIPTION
First time, ansible creates the temporal directory and cron script
deletes it when it's done. It was not being created again.

Instead of creating and deleting temporal directories, let's keep a
private temporal directory and just clean its known contents.