### PR TITLE
Upgrade paulfantom.restic dependency to 0.13.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,8 +29,5 @@ galaxy_info:
      - backups
 
 dependencies:
-  # There's a fix after v 0.12.1 that isn't packed in any version yet
-  # Please consider updating and testing if a newer version is available.
-  - src: https://github.com/paulfantom/ansible-restic.git
-    version: 144f67033bcc6baabef2715aaaf890973be83c17
-    name: paulfantom.restic
+  - name: paulfantom.restic
+    version: 0.13.0


### PR DESCRIPTION
fixes #6 Update paulfantom's restic dependency

tested with odoo-provisioning @[84db594c "Merge branch 'fix-dash-underscore' into 'master'"](https://gitlab.com/coopdevs/odoo-provisioning/commit/84db594c67e74d2f8fa694de3561bb0590a4ef37)