### PR TITLE
Add restore backup task.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 backups_role_restic_version: '0.9.3'
-backups_role_script_path: '/opt/backup'
-backups_role_tmp_path: "{{ backups_role_script_path }}/.tmp"
+backups_role_path: '/opt/backup'
+backups_role_script_path: "{{ backups_role_path }}/bin"
+backups_role_tmp_path: "{{ backups_role_path }}/.tmp"
+backups_role_restore_path: "{{ backups_role_path }}/restore"
 backups_role_config_paths:
     - '/etc'
     - '/root'

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -7,7 +7,7 @@
     group: "{{ backups_role_user_group }}"
     mode: 0775
 
-# Use the the restic helper installed by paulfantom.restic 
+# Use the restic helper installed by paulfantom.restic 
 # "These scripts are named after your repository and will ensure environment variables are correct for that repository."
 # In backups_role case, the restic repo name is set by default in {{ backups_role_restic_repo_name }}.
 # See: https://github.com/paulfantom/ansible-restic/tree/0.13.0#helpers

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure directory for snapshot restore exists
+  file:
+    path: "{{ backups_role_restore_path }}"
+    state: directory
+    owner: "{{ backups_role_user_name }}"
+    group: "{{ backups_role_user_group }}"
+    mode: 0775
+
+- name: Restore last backup for this restic repo
+  command: "restic-{{ backups_role_restic_repo_name }} restore latest --target {{ backups_role_restore_path }}"
+  become: yes
+  become_user: "{{ backups_role_user_name }}"

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -7,6 +7,10 @@
     group: "{{ backups_role_user_group }}"
     mode: 0775
 
+# Use the the restic helper installed by paulfantom.restic 
+# "These scripts are named after your repository and will ensure environment variables are correct for that repository."
+# In backups_role case, the restic repo name is set by default in {{ backups_role_restic_repo_name }}.
+# See: https://github.com/paulfantom/ansible-restic/tree/0.13.0#helpers
 - name: Restore last backup for this restic repo
   command: "restic-{{ backups_role_restic_repo_name }} restore latest --target {{ backups_role_restore_path }}"
   become: yes


### PR DESCRIPTION
It can be imported from secondary playbooks doing:
```yml
- name: Restore_backup
  tasks:
    - include_role:
        name: coopdevs.backups_role
        tasks_from: restore.yml
        vars_from: main.yml
```
By default roles directive and import and include only use `tasks/main.yml`
Fixes #2 

When importing this task, make sure that the restic-hostname script is executable by backups user.