### PR TITLE
Add support for more than 1 DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ backups_role_user_group: 'backups'
 backups_role_postgresql_user_name: "{{ backups_role_user_name }}"
 # Postgres internal admin role
 postgresql_user: "postgres"
-backups_role_db_name: "postgres"
+backups_role_db_names: [ "postgres" ]
 
 # Restic repository name used only in case
 #+ we need to address different restic repos
@@ -57,8 +57,8 @@ backups_role_restic_repo_name: {{ ansible.hostname }}
 ###  defaults/secrets.yml.example     ###
 #########################################
 
-# Password for postgresql unprivileged backups user 
-backups_role_postgresql_user_passwd
+# Password for postgresql unprivileged backups user
+backups_role_postgresql_user_passwd:
 
 # Restic repository password
 backups_role_restic_repo_password:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ backups_role_postgresql_user_name: "{{ backups_role_user_name }}"
 # manager user
 postgresql_user: "postgres"
 backups_role_db_name: "postgres"
+backups_role_db_names: [ "{{ backups_role_db_name }}" ]
 
 # Fix to use python3 with ansible's postgresql module
 postgresql_python_library: "python3-psycopg2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
 
 - name: Ensure postgresql "role" for backups exists with limited access to db
   postgresql_user:
-    db: "{{ backups_role_db_name }}"
+    db: "{{ item }}"
     name: "{{ backups_role_postgresql_user_name }}"
     password: "{{ backups_role_postgresql_user_password }}"
     # This provides '{{ name  }}=c/{{ become_user }}' in {{ db }} database
@@ -64,20 +64,22 @@
     priv: "CONNECT"
   become: true
   become_user: "{{ postgresql_user }}"
+  with_items: "{{ backups_role_db_names }}"
 
-- name: Ensure postgresql "role" for backups has "select" access to any table in {{ backups_role_db_name }}
+- name: Ensure postgresql "role" for backups has "select" access to any table in {{ backups_role_db_names }}
   postgresql_privs:
-    db: "{{ backups_role_db_name }}"
+    db: "{{ item }}"
     role: "{{ backups_role_postgresql_user_name }}"
     objs: ALL_IN_SCHEMA
     # This ensures that this priv exists: {{ role }}=r/{{ become_user }}
     privs: SELECT
   become: true
   become_user: "{{ postgresql_user }}"
+  with_items: "{{ backups_role_db_names }}"
 
-- name: Ensure postgresql "role" for backups has no other access to any table in {{ backups_role_db_name }}
+- name: Ensure postgresql "role" for backups has no other access to any table in {{ backups_role_db_names }}
   postgresql_privs:
-    db: "{{ backups_role_db_name }}"
+    db: "{{ item }}"
     role: "{{ backups_role_postgresql_user_name }}"
     objs: ALL_IN_SCHEMA
     # Revoke all privs except SELECT
@@ -86,6 +88,7 @@
     state: absent
   become: true
   become_user: "{{ postgresql_user }}"
+  with_items: "{{ backups_role_db_names }}"
 
 - name: Let backup user to use `{{ backups_role_sudoers_cmd_pattern }}` as root
   template:

--- a/templates/cron-prepare.sh.j2
+++ b/templates/cron-prepare.sh.j2
@@ -33,7 +33,9 @@ function title {
 # popd
 
 title "Postgres DB dump"
-/usr/bin/pg_dump --encoding=UTF8 {{ backups_role_db_name }} > {{ backups_role_tmp_path }}/pg_dump
+for DB in {{ backups_role_db_names | map('quote') | join(' ')}}; do
+  /usr/bin/pg_dump --encoding=UTF8 "$DB" > "{{ backups_role_tmp_path }}/pg_dump_$DB"
+done
 echo "...done"
 
 title "Compress configuration files"

--- a/templates/cron-prepare.sh.j2
+++ b/templates/cron-prepare.sh.j2
@@ -33,7 +33,7 @@ function title {
 # popd
 
 title "Postgres DB dump"
-for DB in {{ backups_role_db_names | map('quote') | join(' ')}}; do
+for DB in "{{ backups_role_db_names | join('" "')  }}"; do
   /usr/bin/pg_dump --encoding=UTF8 "$DB" > "{{ backups_role_tmp_path }}/pg_dump_$DB"
 done
 echo "...done"

--- a/templates/cron-prepare.sh.j2
+++ b/templates/cron-prepare.sh.j2
@@ -33,6 +33,17 @@ function title {
 # popd
 
 title "Postgres DB dump"
+{# jinja comment.
+ Next non-comment line below should render to something like:
+ for DB in "main" "secondary" "test"; do
+ But a simple | join(' ') would render instead to:
+ for DB in main secondary test; do
+ Thus, we do join('" "'):
+ for DB in main" "secondary" "test; do
+ And add the missing double quotes as literals outside jinja's reach, like
+ "{{ ... }}"
+ https://stackoverflow.com/a/49692186/3625897
+#}
 for DB in "{{ backups_role_db_names | join('" "')  }}"; do
   /usr/bin/pg_dump --encoding=UTF8 "$DB" > "{{ backups_role_tmp_path }}/pg_dump_$DB"
 done

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -12,10 +12,12 @@ function title {
 title "Restic backup"
 restic backup \
   {% if backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
-	{{ backups_role_tmp_path }}/pg_dump \
-	{{ backups_role_tmp_path }}/config.tar.gz \
+  {% for db in backups_role_db_names %}
+  "{{ backups_role_tmp_path }}/pg_dump_{{ db }}" \
+  {% endfor %}
+  "{{ backups_role_tmp_path }}/config.tar.gz" \
   {% endif %}
-	{{ backups_role_assets_paths|join(' ') }}
+  {{ backups_role_assets_paths|join(' ') }}
 
 echo "...done"
 


### PR DESCRIPTION
We don't break compatibility with older inventories: by default, we populate the db names array with 1 item, the former db name
Also, update README.md accordingly and also in README add a missing colon and trim a trailing space