### PR TITLE
Keep also weekly backups / snapshots

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,36 @@ backups_role_script_main:    "{{ backups_role_script_path }}/backup.sh"
 backups_role_script_prepare: "{{ backups_role_script_path }}/backup_prepare.sh"
 backups_role_script_upload:  "{{ backups_role_script_path }}/backup_upload.sh"
 
+# Restic forget policy:
+# How many snapshots do we want to keep?
+#
+# Rules for keep_T: N
+# - For last N units of time T {hour, day, week, month, year},
+#   that have snapshots, keep among them only the most recent N snapshots.
+# - Overlapping "keep_" filters have a safe "OR" effect: a snapshot just needs
+#   one matching filter to be kept.
+#
+# Implications
+# - 1st latest, 1st daily and 1st weekly are always the same snapshot.
+# - if backups are only done weekly, then keep_{weekly, daily, hourly, last}
+#   are redundant, as only units of time (like hours) that have a snapshot are
+#   taken into account, even if they are from different greater units (days, weeks).
+# - when combining non divisor/multiple units (like weeks and months) the
+#   total amount of kept snapshots may fluctuate.
+#
+# Note:
+# - setting one keep filter variable to 0 has a safe ignore effect
+# - official docs: https://restic.readthedocs.io/en/stable/060_forget.html#removing-snapshots-according-to-a-policy
+#
+# Total kept snapshots:
+# with last=4, daily=3, weekly=4 and daily automatic backups:
+# - `last` only takes effect if more than one snapshot is taken in a day, that is, manualy.
+# - `daily` will keep 3 daily snapshots
+# - `weekly` will keep 3 extra snapshots, last Sundays.
+
+backups_role_keep_last: 4
+backups_role_keep_hourly: 0
+backups_role_keep_daily: 3
+backups_role_keep_weekly: 4
+backups_role_keep_monthly: 0
+backups_role_keep_yearly: 0

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -19,7 +19,14 @@ restic backup \
 echo "...done"
 
 title "Restic forget"
-restic forget --keep-last 5 --prune
+restic forget \
+  --keep-last    {{ backups_role_keep_last }} \
+  --keep-hourly  {{ backups_role_keep_hourly }} \
+  --keep-daily   {{ backups_role_keep_daily }} \
+  --keep-weekly  {{ backups_role_keep_weekly }} \
+  --keep-monthly {{ backups_role_keep_monthly }} \
+  --keep-yearly  {{ backups_role_keep_yearly }} \
+  --prune
 echo "...done"
 
 title "Restic check"


### PR DESCRIPTION
Make a wider use of restic forget policies and enable them to be
configured through role variables by importing playbooks, so that they
can customize them.