### PR TITLE
Additional groups for backups user

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ backups_role_tmp_path: '/tmp/backups'
 backups_role_config_paths: ['/etc', '/root', '/usr/local/etc']
 backups_role_assets_paths: []
 
-# System user and group. Who will run scripts, restic and cron jobs
+# System user, its primary group, and additional ones.
+#+ Who will run scripts, restic and cron jobs
 #+  and will own directories and files
 backups_role_user_name: 'backups'
 backups_role_user_group: 'backups'
+backups_role_user_groups: ''
 
 # Postgresql internal read-only role to perform the dump
 backups_role_postgresql_user_name: "{{ backups_role_user_name }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ backups_role_restic_repo_name: "{{ ansible_hostname }}"
 
 backups_role_user_name: 'backups'
 backups_role_user_group: 'backups'
+# Secondary groups to grant user additional permissions
+backups_role_user_groups: ''
 backups_role_sudoers_cmd_pattern: '/bin/tar -czvf *'
 
 # Log files of the backup scripts run by cron

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,21 @@
 ---
-- name: Ensure group for backups user exists
+- name: Ensure primary group for backups user exists
   group:
     name: "{{ backups_role_user_group }}"
     state: present
+
+- name: Ensure additional groups for backups user exist
+  group:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ backups_role_user_groups.split(',') }}"
+  when: backups_role_user_groups != ''
 
 - name: Ensure restricted user for backups exists
   user:
     name: "{{ backups_role_user_name }}"
     group: "{{ backups_role_user_group }}"
+    groups: "{{ backups_role_user_groups }}"
     system: true
     state: present
   when: backups_role_user_name != 'root'


### PR DESCRIPTION
Permit backups user to join secondary groups to be able to perform more actions in overwritten templates. For example, to join `docker` group to run commands inside containers.

This could be used to join `www-data`, for instance, to be able to access web contents. However, we already allow backups user to perform a read only tar operation as root, in order to create backups of any folder.