### PR TITLE
Disable postgres and tar tasks when unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ backups_role_script_dir: "{{ backups_role_path }}/bin"
 #+ the rendered script `backups_role_script_path`
 backups_role_script_prepare_template: "cron-prepare.sh.j2"
 
-# If you modify the prepare_template var, then it means that you are not using
+# If you modify backups_role_script_prepare_template , then it means that you are not using
 #+ this script template and therefore we don't need to create postgres roles, etc.
 #+ and you may not need sudoer permissions for tar. Therefore, we disable
 #+ the related tasks by default. However, if you would like to enable those tasks,
-#+ set to true the correspondant variable:
+#+ set to true the corresponding variables:
 backups_role_postgresql_enabled:
 backups_role_sudoers_enabled:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ backups_role_script_dir: "{{ backups_role_path }}/bin"
 backups_role_script_prepare_template: "cron-prepare.sh.j2"
 
 # If you modify backups_role_script_prepare_template , then it means that you are not using
-#+ this script template and therefore we don't need to create postgres roles, etc.
+#+ the default script template and therefore we don't need to create postgres roles, etc.
 #+ and you may not need sudoer permissions for tar. Therefore, we disable
 #+ the related tasks by default. However, if you would like to enable those tasks,
 #+ set to true the corresponding variables:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ backups_role_script_dir: "{{ backups_role_path }}/bin"
 #+ the rendered script `backups_role_script_path`
 backups_role_script_prepare_template: "cron-prepare.sh.j2"
 
+# If you modify the prepare_template var, then it means that you are not using
+#+ this script template and therefore we don't need to create postgres roles, etc.
+#+ and you may not need sudoer permissions for tar. Therefore, we disable
+#+ the related tasks by default. However, if you would like to enable those tasks,
+#+ set to true the correspondant variable:
+backups_role_postgresql_enabled:
+backups_role_sudoers_enabled:
+
 # Complete path to rendered script formed by main, prepare and upload.
 backups_role_script_path:    "{{ backups_role_script_dir }}/backup.sh"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ backups_role_user_name: 'backups'
 backups_role_user_group: 'backups'
 # Secondary groups to grant user additional permissions
 backups_role_user_groups: ''
+backups_role_sudoers_enabled: true
 backups_role_sudoers_cmd_pattern: '/bin/tar -czvf *'
 
 # Log files of the backup scripts run by cron
@@ -24,6 +25,7 @@ backups_role_cron_stdout_file: '/var/log/cron.d/restic-stdout.log'
 backups_role_cron_stderr_file: '/var/log/cron.d/restic-stderr.log'
 
 # read only user
+backups_role_postgresql_enabled: true
 backups_role_postgresql_user_name: "{{ backups_role_user_name }}"
 # manager user
 postgresql_user: "postgres"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 backups_role_restic_version: '0.9.3'
 backups_role_path: '/opt/backup'
 backups_role_script_dir: "{{ backups_role_path }}/bin"
+backups_role_script_path: "{{ backups_role_script_dir }}/backup.sh"
+backups_role_script_prepare_template: "cron-prepare.sh.j2"
 backups_role_tmp_path: "{{ backups_role_path }}/.tmp"
 backups_role_restore_path: "{{ backups_role_path }}/restore"
 backups_role_config_paths:
@@ -17,7 +19,6 @@ backups_role_user_name: 'backups'
 backups_role_user_group: 'backups'
 # Secondary groups to grant user additional permissions
 backups_role_user_groups: ''
-backups_role_sudoers_enabled: true
 backups_role_sudoers_cmd_pattern: '/bin/tar -czvf *'
 
 # Log files of the backup scripts run by cron
@@ -25,7 +26,6 @@ backups_role_cron_stdout_file: '/var/log/cron.d/restic-stdout.log'
 backups_role_cron_stderr_file: '/var/log/cron.d/restic-stderr.log'
 
 # read only user
-backups_role_postgresql_enabled: true
 backups_role_postgresql_user_name: "{{ backups_role_user_name }}"
 # manager user
 postgresql_user: "postgres"
@@ -34,12 +34,6 @@ backups_role_db_names: [ "{{ backups_role_db_name }}" ]
 
 # Fix to use python3 with ansible's postgresql module
 postgresql_python_library: "python3-psycopg2"
-
-
-# Backup scripts
-
-backups_role_script_prepare_template: "cron-prepare.sh.j2"
-backups_role_script_path: "{{ backups_role_script_dir }}/backup.sh"
 
 # Restic forget policy:
 # How many snapshots do we want to keep?

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
   become: true
   become_user: "{{ postgresql_user }}"
   with_items: "{{ backups_role_db_names }}"
-  when: backups_role_postgresql_enabled
+  when: _backups_role_postgresql_enabled
 
 - name: Ensure postgresql "role" for backups has "select" access to any table in {{ backups_role_db_names }}
   postgresql_privs:
@@ -61,7 +61,7 @@
   become: true
   become_user: "{{ postgresql_user }}"
   with_items: "{{ backups_role_db_names }}"
-  when: backups_role_postgresql_enabled
+  when: _backups_role_postgresql_enabled
 
 - name: Ensure postgresql "role" for backups has no other access to any table in {{ backups_role_db_names }}
   postgresql_privs:
@@ -75,7 +75,7 @@
   become: true
   become_user: "{{ postgresql_user }}"
   with_items: "{{ backups_role_db_names }}"
-  when: backups_role_postgresql_enabled
+  when: _backups_role_postgresql_enabled
 
 - name: Let backup user to use `{{ backups_role_sudoers_cmd_pattern }}` as root
   template:
@@ -83,7 +83,7 @@
     dest: "/etc/sudoers.d/90-backup-user"
     mode: 0440
     group: "root"
-  when: backups_role_sudoers_enabled
+  when: _backups_role_sudoers_enabled
 
 - name: Install restic and configure restic repository
   include_role:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
   become: true
   become_user: "{{ postgresql_user }}"
   with_items: "{{ backups_role_db_names }}"
+  when: backups_role_postgresql_enabled
 
 - name: Ensure postgresql "role" for backups has "select" access to any table in {{ backups_role_db_names }}
   postgresql_privs:
@@ -60,6 +61,7 @@
   become: true
   become_user: "{{ postgresql_user }}"
   with_items: "{{ backups_role_db_names }}"
+  when: backups_role_postgresql_enabled
 
 - name: Ensure postgresql "role" for backups has no other access to any table in {{ backups_role_db_names }}
   postgresql_privs:
@@ -73,6 +75,7 @@
   become: true
   become_user: "{{ postgresql_user }}"
   with_items: "{{ backups_role_db_names }}"
+  when: backups_role_postgresql_enabled
 
 - name: Let backup user to use `{{ backups_role_sudoers_cmd_pattern }}` as root
   template:
@@ -80,6 +83,7 @@
     dest: "/etc/sudoers.d/90-backup-user"
     mode: 0440
     group: "root"
+  when: backups_role_sudoers_enabled
 
 - name: Install restic and configure restic repository
   include_role:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,13 @@
 ---
 # vars file for backups_role
+
+# Check if cron script template of prepare backup, is the default one (true) or has been overriden (false)
+_template_is_default: {% backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
+# If swithces have been set at the inventory, respect them.
+# Otherwise, switch them off when the template has changed.
+backups_role_sudoers_enabled: {{ backups_role_sudoers_enabled | default(_template_is_default) }}
+backups_role_postgresql_enabled: {{ backups_role_postgresql_enabled | default(_template_is_default) }}
+
 backups_role_restic_repo:
   name: "{{ backups_role_restic_repo_name }}"
   url: "{{ backups_role_restic_repo_url }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,11 +2,11 @@
 # vars file for backups_role
 
 # Check if cron script template of prepare backup, is the default one (true) or has been overriden (false)
-_template_is_default: {% backups_role_script_prepare_template == "cron-prepare.sh.j2" %}
+_template_is_default: "{{ backups_role_script_prepare_template == 'cron-prepare.sh.j2' }}"
 # If swithces have been set at the inventory, respect them.
 # Otherwise, switch them off when the template has changed.
-backups_role_sudoers_enabled: {{ backups_role_sudoers_enabled | default(_template_is_default) }}
-backups_role_postgresql_enabled: {{ backups_role_postgresql_enabled | default(_template_is_default) }}
+_backups_role_sudoers_enabled: "{{ backups_role_sudoers_enabled | default(_template_is_default) }}"
+_backups_role_postgresql_enabled: "{{ backups_role_postgresql_enabled | default(_template_is_default) }}"
 
 backups_role_restic_repo:
   name: "{{ backups_role_restic_repo_name }}"


### PR DESCRIPTION
This feature is needed for playbooks that don't have postgres install in the host (at least directly, not inside container), and still want to use this role.

If you modify the `backups_role_script_prepare_template` var, then it means that you are not using
this script template and therefore we don't need to create postgres roles, etc.                 
and you may not need sudoer permissions for tar. Therefore, we disable                                
the related tasks by default. However, if you still would like to enable those tasks,
set to true the corresponding variables:

* `backups_role_postgresql_enabled`
* `backups_role_sudoers_enabled`

~~Don't merge until #25 is merged. Otherwise it can overwrite some changes we did~~
Funny enough, I did it in the reverse order and I had no problem. ough...