### PR TITLE
Do not backup non-existing config.tar.gz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not backup non-existing `config.tar.gz` with the restic command [#36](https://github.com/coopdevs/backups_role/pull/36)
+
 ## [v1.2.3] - 2019-12-03
 
 ### Removed
 
 - `backups_role_config_paths` as we don't see the point on backing up anything
     other than a single path with assets. We always have a provisioning repo
-    that is able to setup a new server with its config.
+    that is able to setup a new server with its config [#34](https://github.com/coopdevs/backups_role/pull/34/files)

--- a/templates/cron-upload.sh.j2
+++ b/templates/cron-upload.sh.j2
@@ -5,7 +5,6 @@ restic backup \
   {% for db in backups_role_db_names %}
   "{{ backups_role_tmp_path }}/pg_dump_{{ db }}" \
   {% endfor %}
-  "{{ backups_role_tmp_path }}/config.tar.gz" \
   {% endif %}
   {{ backups_role_assets_paths|join(' ') }}
 


### PR DESCRIPTION
This was a leftover from https://github.com/coopdevs/backups_role/pull/34 and causes the following warning

```
Tue Dec  3 18:12:12 CET 2019
/opt/backup/.tmp/config.tar.gz does not exist, skipping
```