### PR TITLE
Release/v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v1.2.6] - 2020-01-23
 ### Changed
 - Fix: when using default backups-prepare script, manage the case when no assets_paths are defined
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [v1.2.6] - 2020-01-23
-### Changed
-- Fix: when using default backups-prepare script, manage the case when no assets_paths are defined.
+### Fixed
+- When using default backups-prepare script, manage the case when no assets_paths are defined.
   See [#38](https://github.com/coopdevs/backups_role/pull/38)
 
 ## [v1.2.5] - 2020-01-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v1.2.6] - 2020-01-23
 ### Changed
-- Fix: when using default backups-prepare script, manage the case when no assets_paths are defined
+- Fix: when using default backups-prepare script, manage the case when no assets_paths are defined.
+  See [#38](https://github.com/coopdevs/backups_role/pull/38)
 
 ## [v1.2.5] - 2020-01-20
 ### Changed


### PR DESCRIPTION
## [v1.2.6] - 2020-01-23
### Changed
- Fix: when using default backups-prepare script, manage the case when no assets_paths are defined.
  See [#38](https://github.com/coopdevs/backups_role/pull/38)
