### PR TITLE
Grant USAGE on public schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   # Check the role/playbook's syntax.
   - ansible-galaxy install paulfantom.restic
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
-  - ansible-lint .
+  - ansible-lint tasks/ handlers/
   - yamllint -c .yamllint.yaml .
 
 webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ensure the backups user has USAGE privilage on the database's schema. We assume it to be`public` #41.
+
 ## [v1.2.6] - 2020-01-23
 ### Fixed
 - When using default backups-prepare script, manage the case when no assets_paths are defined.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,17 @@
   with_items: "{{ backups_role_db_names }}"
   when: _backups_role_postgresql_enabled
 
+- name: Grant USAGE priv on public schema
+  postgresql_privs:
+    db: "{{ backups_role_db_names[0] }}"
+    role: "{{ backups_role_postgresql_user_name }}"
+    privs: USAGE
+    type: schema
+    objs: public
+  become: true
+  become_user: "{{ postgresql_user }}"
+  when: _backups_role_postgresql_enabled
+
 - name: Include taskfile for postgresql privileges
   include_tasks: postgresql_privs.yml
   loop: "{{ backups_role_db_names }}"


### PR DESCRIPTION
The DB user executing pg_dump needs USAGE privileges on the database's schema. SELECT privileges on the individual tables within are not enough.

This gets rid of the following error from `/var/log/cron.d/restic-stderr.log`:

```
Fri Dec 11 03:45:01 CET 2020
pg_dump: [archiver (db)] query failed: ERROR:  permission denied for relation accounts
pg_dump: [archiver (db)] query was: LOCK TABLE public.accounts IN ACCESS SHARE MODE
```

After this backups are coming through.