### PR TITLE
Replace paulfantom restic role because of no maintenace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 script:
   # Check the role/playbook's syntax.
-  - ansible-galaxy install paulfantom.restic
+  - ansible-galaxy install coopdevs.ansible_restic
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
   - ansible-lint tasks/ handlers/
   - yamllint -c .yamllint.yaml .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.10] - 2023-08-16
+### Fixed
+- Replace paulfantom restic role because of no maintenace
+  See [#45](https://github.com/coopdevs/backups_role/pull/45)
+
 ## [v1.2.9] - 2022-08-04
 ### Fixed
 - Escape dollar character in docker compose

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Backup and restore strategies for Coopdevs projects.
 Requirements
 ------------
 
-This role uses [Restic](https://restic.net) with the help of [restic-ansible](https://github.com/paulfantom/ansible-restic)
+This role uses [Restic](https://restic.net) with the help of [restic-ansible](https://github.com/coopdevs/restic-role)
 
 Role Variables
 --------------
@@ -88,7 +88,7 @@ backups_role_b2_app_key:
 Dependencies
 ------------
 
-* [paulfantom.restic](https://galaxy.ansible.com/paulfantom/restic)
+* [coopdevs.ansible_restic](https://github.com/coopdevs/restic-role)
 
 Usage
 -----

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,8 +22,7 @@ galaxy_info:
      - backups
 
 dependencies:
-  - name: paulfantom.restic
-    version: 0.13.0
+  - name: coopdevs.ansible_restic
     # We don't want the role to run
     # when we import tasks from restore-to-controller,
     # as it is executed locally to the controller machine

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
 
 - name: Install restic and configure restic repository
   include_role:
-    name: vendor/paulfantom.restic
+    name: vendor/coopdevs.ansible_restic
   vars:
     restic_version: "{{ backups_role_restic_version }}"
     restic_user: "{{ backups_role_user_name }}"

--- a/tasks/restore-to-controller.yml
+++ b/tasks/restore-to-controller.yml
@@ -30,12 +30,12 @@
 
   - name: Configure restic
     import_role:
-      name: paulfantom.restic
+      name: coopdevs.ansible_restic
       tasks_from: preflight.yml
 
   - name: Install restic using restic-role
     import_role:
-      name: paulfantom.restic
+      name: coopdevs.ansible_restic
       tasks_from: install.yml
     vars:
     - restic_install_path: "{{ work_path }}"
@@ -49,7 +49,7 @@
 
   - name: Render script template that wraps restic with credentials
     template:
-      src: '../vendor/paulfantom.restic/templates/restic.helper.j2'
+      src: '../vendor/coopdevs.ansible_restic/templates/restic.helper.j2'
       dest: "{{ work_path }}/restic-{{ backups_role_restic_repo_name }}"
       mode: '0750'
     no_log: true


### PR DESCRIPTION
After finding the following error in odoo-provisioning

TASK [paulfantom.restic : Set proper capabilities for restic binary] **************
Monday 14 August 2023 14:25:22 +0200 (0:00:02.845) 0:06:41.890 *****
fatal: [saas.coopdevs.org]: FAILED! => {"changed": false, "msg": "Unable to get capabilities of /usr/local/bin/restic", "stderr": "", "stderr_lines": [], "stdout": "/usr/local/bin/restic cap_dac_read_search=ep", "stdout_lines": ["/usr/local/bin/restic cap_dac_read_search=ep"]}

we realised paulfantom.restic is not maintained anymore https://github.com/ansible/ansible/issues/72662 so we made a fork to fix it https://github.com/coopdevs/restic-role.

This MR implements this change of dependency in backups-role. 