### PR TITLE
feat: upgrade restic to 0.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Update restic version to latest (v0.16.4)
+  See [#46](https://github.com/coopdevs/backups_role/pull/46)
+
 ## [v1.2.10] - 2023-08-16
 ### Fixed
 - Replace paulfantom restic role because of no maintenace

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Role Variables
 --------------
 ```yaml
 # Restic version
-backups_role_restic_version: '0.9.3'
+backups_role_restic_version: '0.16.4'
 
 # Location of the scripts
 backups_role_path: '/opt/backup'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-backups_role_restic_version: '0.9.3'
+backups_role_restic_version: '0.16.4'
 backups_role_path: '/opt/backup'
 backups_role_script_dir: "{{ backups_role_path }}/bin"
 backups_role_script_path: "{{ backups_role_script_dir }}/backup.sh"


### PR DESCRIPTION
Bump restic version to latest (0.16.4).

- There are several improvements and fixes across all new releases. Those which motivate us to update version are the related to the improvement speed of `restic prune`.