### PR TITLE
fix: remove vendor path from roles

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
 
 - name: Install restic and configure restic repository
   include_role:
-    name: vendor/coopdevs.ansible_restic
+    name: coopdevs.ansible_restic
   vars:
     restic_version: "{{ backups_role_restic_version }}"
     restic_user: "{{ backups_role_user_name }}"

--- a/tasks/restore-to-controller.yml
+++ b/tasks/restore-to-controller.yml
@@ -49,7 +49,7 @@
 
   - name: Render script template that wraps restic with credentials
     template:
-      src: '../vendor/coopdevs.ansible_restic/templates/restic.helper.j2'
+      src: 'coopdevs.ansible_restic/templates/restic.helper.j2'
       dest: "{{ work_path }}/restic-{{ backups_role_restic_repo_name }}"
       mode: '0750'
     no_log: true


### PR DESCRIPTION
Remove `vendor` path prefixes when calling a role.

The roles path should be configured at `ansible.cfg` instead, allowing calls to `namespace.role-name`.